### PR TITLE
pkg: ignore symbol indexing/iterator for ts types.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -762,8 +762,10 @@ function ownKeys(obj) {
   for (const symbol of symbols) {
     const desc = Object.getOwnPropertyDescriptor(obj, symbol);
 
-    if (desc && desc.enumerable)
+    if (desc && desc.enumerable) {
+      // @ts-ignore
       keys.push(symbol);
+    }
   }
 
   return keys;


### PR DESCRIPTION
Allow recursive typescript checks from dependants to the bsert to work, allowing us to use typescript as a type linter with jsdoc.
